### PR TITLE
feat: add support for files and videos

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    md-to-notion (0.1.0)
+    md_to_notion (0.1.3)
 
 GEM
   remote: https://rubygems.org/
@@ -54,7 +54,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  md-to-notion!
+  md_to_notion!
   pry
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/lib/md_to_notion/blocks.rb
+++ b/lib/md_to_notion/blocks.rb
@@ -87,13 +87,13 @@ module MdToNotion
       block
     end
 
-    def self.image
+    def self.file(url, type:)
       {
-        type: "image",
-        image: {
+        type: type,
+        "#{type}": {
           type: "external",
           external: {
-            url: link
+            url: url
           }
         }
       }

--- a/lib/md_to_notion/parser.rb
+++ b/lib/md_to_notion/parser.rb
@@ -33,7 +33,10 @@ module MdToNotion
         when :numbered_list
           Block.numbered_list(token[:rich_texts])
         when :image
-          Block.image(token[:text], token[:rich_texts])
+          Block.file(token[:url], type: "image")
+        when :embeded_file
+          # @TODO support more file types
+          Block.file(token[:url], type: "video")
         when :quote
           Block.quote(token[:rich_texts])
         end

--- a/lib/md_to_notion/tokens.rb
+++ b/lib/md_to_notion/tokens.rb
@@ -10,6 +10,8 @@ module MdToNotion
     NUMBERED_LIST = /^([0-9]+)\. (.+)/.freeze
     IMAGE = /!\[([^\]]+)\]\(([^)]+)\)/.freeze
     QUOTE = /^> (.+)/.freeze
+    GH_EMBED_FILE = %r{https://user-images\.githubusercontent\.com/.+\.[a-zA-Z]+}.freeze
+    EMBED_FILE_REGEXES = [GH_EMBED_FILE].freeze
 
     def heading_1(match)
       { type: :heading_1, rich_texts: tokenize_rich_text(match.gsub(/^# /, "")) }
@@ -51,8 +53,7 @@ module MdToNotion
     def image(match)
       {
         type: :image,
-        rich_texts: tokenize_rich_text(match.gsub(/!\[([^\]]+)\]\(([^)]+)\)/, '\1')),
-        link: match.gsub(/!\[([^\]]+)\]\(([^)]+)\)/, '\2')
+        url: match.gsub(/!\[([^\]]+)\]\(([^)]+)\)/, '\2')
       }
     end
 
@@ -62,6 +63,13 @@ module MdToNotion
 
     def quote(match)
       { type: :quote, rich_texts: tokenize_rich_text(match.gsub(/^> /, "")) }
+    end
+
+    def embeded_file(match)
+      {
+        type: :embeded_file,
+        url: match
+      }
     end
 
     ## rich text objects

--- a/spec/fixtures/test1.md
+++ b/spec/fixtures/test1.md
@@ -15,3 +15,8 @@ int main() {
   return 0;
 }
 ```
+
+https://user-images.githubusercontent.com/58893812/211213302-7f38960c-dd35-4955-8115-166f83d9c3ed.mov
+
+![an image](https://image.jpeg)
+

--- a/spec/fixtures/test1_blocks.json
+++ b/spec/fixtures/test1_blocks.json
@@ -176,5 +176,23 @@
       ],
       "language": "c"
     }
+  },
+  {
+    "type": "video",
+    "video": {
+      "type": "external",
+      "external": {
+        "url": "https://user-images.githubusercontent.com/58893812/211213302-7f38960c-dd35-4955-8115-166f83d9c3ed.mov"
+      }
+    }
+  },
+  {
+    "type": "image",
+    "image": {
+      "type": "external",
+      "external": {
+        "url": "https://image.jpeg"
+      }
+    }
   }
 ]


### PR DESCRIPTION
This PR adds support for images and videos. 

Videos are only supported in github flavored markdown. The Lexer#tokenize checks for any url that matches `"https://user-images.githubusercontent.com/"` --the only allowed url for now, but there could be more-- and if it finds a match, returns a video block.

closes #1 